### PR TITLE
test: add successful and failing test cases in test.c

### DIFF
--- a/gentest/test.c
+++ b/gentest/test.c
@@ -50,12 +50,88 @@ void test_successful_encoding(void) {
 	TEST_ASSERT_EQUAL(0x00, frame.data[7]);
 }
 
+void test_successful_decoding_clamping(void) {
+	vera_can_rx_frame_t frame = {
+		.id = 0x7b, // 123
+		.dlc = 8,
+		.data = {0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00}, // RPM value above max level
+	};
+	vera_decoded_signal_t signals[vera_n_signals_Message1];
+	vera_decoding_result_t result = {
+		.n_signals = 0,
+		.decoded_signals = signals
+	};
+
+	vera_err_t err = vera_decode_can_frame(&frame, &result);
+	TEST_ASSERT_EQUAL(vera_err_ok, err);
+	
+	// the program will cut the singal at its max allowed value (8000 RPM)
+	TEST_ASSERT_EQUAL_FLOAT(8000.0, result.decoded_signals[0].value); 
+}
+
+void test_succesful_decoding_unknown_id(void) {
+	vera_can_rx_frame_t frame = { .id = 999, .dlc = 8, .data = {0} }; // unknown id
+	vera_decoded_signal_t signals[2];
+	vera_decoding_result_t result = {
+		.n_signals = 0,
+		.decoded_signals = signals
+	};
+
+	vera_err_t err = vera_decode_can_frame(&frame, &result);
+	
+	// the program will ignore the signal
+	TEST_ASSERT_EQUAL(vera_err_ok, err);
+	TEST_ASSERT_EQUAL(0, result.n_signals);
+}
+
+void test_failing_decoding_null_arg(void) {
+	vera_can_rx_frame_t frame = {
+		.id = 123,
+		.dlc = 8,
+		.data = {0}
+	};
+	vera_decoding_result_t result = {
+		.n_signals = 0,
+		.decoded_signals = NULL // NULL pointer, it will fail the test
+	};
+
+	vera_err_t err = vera_decode_can_frame(&frame, &result);
+	TEST_ASSERT_EQUAL(vera_err_null_arg, err);
+}
+
+void test_failing_encoding_null_arg(void) {
+	vera_err_t err = vera_encode_Message1(NULL, 3000, 400); // NULL argument, it will fail the test
+	TEST_ASSERT_EQUAL(vera_err_null_arg, err);
+}
+
+void test_failing_decoding_out_of_bounds(void) {
+	vera_can_rx_frame_t frame = {
+		.id = 123,
+		.dlc = 2, // 2 bytes instead of 6, it will fail the test
+		.data = {0}
+	};
+	vera_decoded_signal_t signals[vera_n_signals_Message1];
+	vera_decoding_result_t result = {
+		.n_signals = 0,
+		.decoded_signals = signals
+	};
+
+	vera_err_t err = vera_decode_can_frame(&frame, &result);
+	TEST_ASSERT_EQUAL(vera_err_out_of_bounds, err);
+}
+
 int main(void) {
 	setvbuf(stdout, NULL, _IONBF, 0); // Disable stdout buffering
 	UNITY_BEGIN();
 
 	RUN_TEST(test_successful_decoding);
 	RUN_TEST(test_successful_encoding);
+	RUN_TEST(test_successful_decoding_clamping);
+	RUN_TEST(test_succesful_decoding_unknown_id);
+	RUN_TEST(test_failing_decoding_null_arg);
+	RUN_TEST(test_failing_encoding_null_arg);
+	RUN_TEST(test_failing_decoding_out_of_bounds);
+
 	return UNITY_END();
 }
 


### PR DESCRIPTION
Addresses #39.

This PR expands the test suite in `gentest/test.c` to improve the logical coverage of the generated C code.

**Changes included:**
* **Failing cases:** Added tests to verify the system correctly returns `vera_err_null_arg` and `vera_err_out_of_bounds`.
* **Successful edge cases:** Added tests for maximum value clamping (e.g., EngineSpeed correctly capped at 8000 RPM) and unknown CAN ID handling.

*Note:* I focused entirely on maximizing the C code test coverage first. The `config-test.dbc` enrichment requested in the original issue will be addressed in a subsequent step.