### PR TITLE
fix: encode standard CAN frame IDs correctly

### DIFF
--- a/codegen/stm32hal/vera_stm32hal.c.tmpl
+++ b/codegen/stm32hal/vera_stm32hal.c.tmpl
@@ -30,7 +30,8 @@ vera_err_t vera_encode_autodevkit_{{.Name}}(
 	if (!frame)	return vera_err_null_arg;
 
 	memset(data, 0, sizeof(uint8_t)*8);
-	frame->ID = {{printf "%#x" .ID}};
+	frame->StdId = {{printf "%#x" .ID}};
+	frame->IDE = CAN_ID_STD;
 	frame->DLC = {{.DLC}};
 	{{range .Signals}}
 	_insert_data_in_payload(data, {{.Name}}, {{.StartBit}}, {{.Length}});


### PR DESCRIPTION
## Summary

- Set generated STM32 HAL frames to use `StdId` for standard CAN IDs.
- Mark encoded frames with `CAN_ID_STD`.

## Testing

- Not run; template-only change.