### PR TITLE
feat: use standard DBC comments for MQTT topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Vera exists to simplify the workflow of working with CAN networks by providing:
 The generated code provides:
 - Signal decoding from raw CAN frames with automatic scaling/offset conversion
 - Signal encoding for creating CAN frames
-- MQTT topic mapping via TP_ instructions, to integrate in MQTT networks and pipelines
+- MQTT topic mapping via standard DBC signal comments, to integrate in MQTT networks and pipelines
 - Validation for out-of-bounds values
 
 ## Installation
@@ -188,14 +188,16 @@ Vera expects DBC files with the following format:
 ```
 BO_ <message_id> <message_name>: <dlc> <transmitter>
     SG_ <signal_name> : <start_bit>|<length>@<endianness><sign> (<factor>,<offset>) [<min>|<max>] "<unit>" <receivers>
-TP_ <signal_name> <mqtt_topic>
+CM_ SG_ <message_id> <signal_name> "vera:mqtt-topic=<mqtt_topic>";
 ```
 
 **Important notes:**
 - Start bit and length are in **bits**, DLC is in **bytes**
 - Receivers are parsed if present, but not used in code generation
 - Only **little-endian** (endiananness `1`) is currently supported
-- TP_ instructions are placed at the same level as BO_ instructions (not indented), and refer to the signals, not the messages
+- MQTT topics use standard DBC `CM_ SG_` comments and are placed at the same level as `BO_` instructions (not indented)
+- The `vera:mqtt-topic=` prefix keeps MQTT configuration distinct from ordinary signal documentation comments
+- Topics are associated with a specific message ID and signal name
 
 ### Example DBC File
 
@@ -203,8 +205,8 @@ TP_ <signal_name> <mqtt_topic>
 BO_ 123 EngineSpeed: 6 Engine
     SG_ EngineSpeed : 0|32@1+ (0.1,0) [0|8000] "RPM" DriverGateway
     SG_ BatteryTemperature : 32|16@1+(12,4) (1,0) [0|8000] "ºC" DriverGateway
-TP_ EngineSpeed vehicle/engine/speed
-TP_ BatteryTemperature vehicle/battery/temperature
+CM_ SG_ 123 EngineSpeed "vera:mqtt-topic=vehicle/engine/speed";
+CM_ SG_ 123 BatteryTemperature "vera:mqtt-topic=vehicle/battery/temperature";
 ```
 
 ## Development

--- a/gentest/config-test.dbc
+++ b/gentest/config-test.dbc
@@ -2,4 +2,4 @@ BO_ 123 Message1: 6 Engine
 	SG_ EngineSpeed : 0|32@1+ (0.1,0) [0|8000] "RPM" DriverGateway
 	SG_ BatteryTemperature : 32|12@1+ (1,400) [0|8000] "ºC" DriverGateway
 
-TP_ EngineSpeed Engine/Metrics/Speed
+CM_ SG_ 123 EngineSpeed "vera:mqtt-topic=Engine/Metrics/Speed";

--- a/parser.go
+++ b/parser.go
@@ -3,8 +3,14 @@ package vera
 import (
 	"fmt"
 	"io"
+	"regexp"
+	"strconv"
 	"strings"
 )
+
+const mqttTopicCommentPrefix = "vera:mqtt-topic="
+
+var signalCommentPattern = regexp.MustCompile(`^CM_\s+SG_\s+(0x[0-9A-Fa-f]+|[0-9]+)\s+(\S+)\s+"((?:[^"\\]|\\.)*)"\s*;\s*$`)
 
 func Parse(r io.Reader) (*Config, error) {
 	bytes, err := io.ReadAll(r)
@@ -40,36 +46,50 @@ func Parse(r io.Reader) (*Config, error) {
 
 			config.Messages = append(config.Messages, *message)
 			i = j - 1
-		} else if strings.HasPrefix(lines[i], "TP_") {
-			signalTopic, err := parseSignalTopic(lines[i])
+		} else if strings.HasPrefix(lines[i], "CM_ SG_") {
+			signalTopic, err := parseSignalTopicComment(lines[i])
 			if err != nil {
 				return nil, err
 			}
 
-			config.Topics = append(config.Topics, *signalTopic)
+			if signalTopic != nil {
+				config.Topics = append(config.Topics, *signalTopic)
+			}
 		}
 	}
 
 	return config, nil
 }
 
-func parseSignalTopic(topicLine string) (*SignalTopic, error) {
-	lineParts := strings.Fields(topicLine)
-	if len(lineParts) != 3 {
-		return nil, fmt.Errorf(`signal topic has wrong structure: %s
+func parseSignalTopicComment(commentLine string) (*SignalTopic, error) {
+	matches := signalCommentPattern.FindStringSubmatch(commentLine)
+	if matches == nil {
+		if strings.Contains(commentLine, mqttTopicCommentPrefix) {
+			return nil, fmt.Errorf(`MQTT topic comment has wrong structure: %s
 Should be:
-	TP_ <SignalName> <Topic>`, topicLine)
+	CM_ SG_ <MessageID> <SignalName> "vera:mqtt-topic=<Topic>";`, commentLine)
+		}
+
+		return nil, nil
 	}
 
-	signalName := lineParts[1]
-	topic := lineParts[2]
-	topic = strings.TrimFunc(topic, func(r rune) bool {
-		return r == '"'
-	})
+	comment, err := strconv.Unquote(`"` + matches[3] + `"`)
+	if err != nil {
+		return nil, fmt.Errorf("invalid signal comment: %w", err)
+	}
+	if !strings.HasPrefix(comment, mqttTopicCommentPrefix) {
+		return nil, nil
+	}
+
+	messageID, err := strconv.ParseUint(matches[1], 0, 32)
+	if err != nil {
+		return nil, fmt.Errorf("invalid message ID in MQTT topic comment: %w", err)
+	}
 
 	signalTopic := &SignalTopic{
-		Topic:  topic,
-		Signal: signalName,
+		MessageID: uint32(messageID),
+		Topic:     strings.TrimPrefix(comment, mqttTopicCommentPrefix),
+		Signal:    matches[2],
 	}
 
 	return signalTopic, nil

--- a/parser_test.go
+++ b/parser_test.go
@@ -26,31 +26,32 @@ BO_ 123 EngineSpeed: 3 Engine
 	})
 }
 
-func TestParseSignalTopic(t *testing.T) {
-	t.Run("should parse valid signal topic", func(t *testing.T) {
+func TestParseSignalTopicComment(t *testing.T) {
+	t.Run("should parse a valid MQTT topic comment", func(t *testing.T) {
 		a := assert.New(t)
 
-		topic, err := parseSignalTopic("TP_ EngineSpeed vehicle/engine/speed")
+		topic, err := parseSignalTopicComment(`CM_ SG_ 123 EngineSpeed "vera:mqtt-topic=vehicle/engine/speed";`)
 		a.Nil(err)
 		a.NotNil(topic)
+		a.Equal(uint32(123), topic.MessageID)
 		a.Equal("EngineSpeed", topic.Signal)
 		a.Equal("vehicle/engine/speed", topic.Topic)
 	})
 
-	t.Run("should return error for invalid structure", func(t *testing.T) {
+	t.Run("should return an error for a malformed MQTT topic comment", func(t *testing.T) {
 		a := assert.New(t)
 
-		topic, err := parseSignalTopic("TP_ EngineSpeed")
+		topic, err := parseSignalTopicComment(`CM_ SG_ 123 EngineSpeed "vera:mqtt-topic=vehicle/engine/speed"`)
 		a.Error(err)
 		a.Nil(topic)
-		a.Contains(err.Error(), "signal topic has wrong structure")
+		a.Contains(err.Error(), "MQTT topic comment has wrong structure")
 	})
 
-	t.Run("should return error for too many fields", func(t *testing.T) {
+	t.Run("should ignore regular signal comments", func(t *testing.T) {
 		a := assert.New(t)
 
-		topic, err := parseSignalTopic("TP_ EngineSpeed vehicle/engine/speed extra")
-		a.Error(err)
+		topic, err := parseSignalTopicComment(`CM_ SG_ 123 EngineSpeed "Engine speed in RPM";`)
+		a.Nil(err)
 		a.Nil(topic)
 	})
 }
@@ -61,7 +62,7 @@ func TestParse_WithTopics(t *testing.T) {
 
 		configStr := `BO_ 123 EngineSpeed: 8 Engine
 	SG_ Speed : 0|2@1+ (0.1,0) [0|100] "km/h" Gateway
-TP_ Speed vehicle/engine/speed`
+CM_ SG_ 123 Speed "vera:mqtt-topic=vehicle/engine/speed";`
 		reader := strings.NewReader(configStr)
 
 		config, err := Parse(reader)
@@ -69,6 +70,7 @@ TP_ Speed vehicle/engine/speed`
 		a.NotNil(config)
 		a.Len(config.Messages, 1)
 		a.Len(config.Topics, 1)
+		a.Equal(uint32(123), config.Topics[0].MessageID)
 		a.Equal("Speed", config.Topics[0].Signal)
 		a.Equal("vehicle/engine/speed", config.Topics[0].Topic)
 	})
@@ -86,14 +88,14 @@ TP_ Speed vehicle/engine/speed`
 		a.Len(config.Topics, 0)
 	})
 
-	t.Run("should skip lines that are not BO_ or TP_", func(t *testing.T) {
+	t.Run("should skip non-topic DBC instructions and comments", func(t *testing.T) {
 		a := assert.New(t)
 
 		configStr := `CM_ "This is a comment"
 BO_ 123 EngineSpeed: 8 Engine
 	SG_ Speed : 0|2@1+ (0.1,0) [0|100] "km/h" Gateway
 BA_ "AttributeName" "AttributeValue"
-TP_ Speed vehicle/engine/speed`
+CM_ SG_ 123 Speed "vera:mqtt-topic=vehicle/engine/speed";`
 		reader := strings.NewReader(configStr)
 
 		config, err := Parse(reader)

--- a/types.go
+++ b/types.go
@@ -15,6 +15,7 @@ const (
 )
 
 type SignalTopic struct {
-	Topic  string
-	Signal string
+	MessageID uint32
+	Topic     string
+	Signal    string
 }

--- a/validator.go
+++ b/validator.go
@@ -2,17 +2,23 @@ package vera
 
 import "fmt"
 
+type signalTopicKey struct {
+	messageID uint32
+	signal    string
+}
+
 func (c *Config) Validate() error {
-	topicsMap := make(map[string]string)
+	topicsMap := make(map[signalTopicKey]string)
 	for i, t := range c.Topics {
 		if err := t.Validate(); err != nil {
 			return fmt.Errorf("topic Nº%d: %w", i, err)
 		}
 
-		if _, ok := topicsMap[t.Signal]; ok {
-			return fmt.Errorf("duplicate signal topic: %s", t.Topic)
+		key := signalTopicKey{messageID: t.MessageID, signal: t.Signal}
+		if _, ok := topicsMap[key]; ok {
+			return fmt.Errorf("duplicate signal topic for message %d, signal %s", t.MessageID, t.Signal)
 		}
-		topicsMap[t.Signal] = t.Topic
+		topicsMap[key] = t.Topic
 	}
 
 	for i := range c.Messages {
@@ -21,7 +27,8 @@ func (c *Config) Validate() error {
 		}
 
 		for j := range c.Messages[i].Signals {
-			if value, ok := topicsMap[c.Messages[i].Signals[j].Name]; ok {
+			key := signalTopicKey{messageID: c.Messages[i].ID, signal: c.Messages[i].Signals[j].Name}
+			if value, ok := topicsMap[key]; ok {
 				c.Messages[i].Signals[j].Topic = value
 			}
 		}

--- a/validator_test.go
+++ b/validator_test.go
@@ -31,8 +31,9 @@ func TestConfigValidate(t *testing.T) {
 			},
 			Topics: []SignalTopic{
 				{
-					Topic:  "vehicle/engine/speed",
-					Signal: "Speed",
+					MessageID: 123,
+					Topic:     "vehicle/engine/speed",
+					Signal:    "Speed",
 				},
 			},
 		}
@@ -48,8 +49,9 @@ func TestConfigValidate(t *testing.T) {
 		config := &Config{
 			Topics: []SignalTopic{
 				{
-					Topic:  "",
-					Signal: "Speed",
+					MessageID: 123,
+					Topic:     "",
+					Signal:    "Speed",
 				},
 			},
 		}
@@ -65,12 +67,14 @@ func TestConfigValidate(t *testing.T) {
 		config := &Config{
 			Topics: []SignalTopic{
 				{
-					Topic:  "vehicle/engine/speed",
-					Signal: "Speed",
+					MessageID: 123,
+					Topic:     "vehicle/engine/speed",
+					Signal:    "Speed",
 				},
 				{
-					Topic:  "vehicle/engine/rpm",
-					Signal: "Speed",
+					MessageID: 123,
+					Topic:     "vehicle/engine/rpm",
+					Signal:    "Speed",
 				},
 			},
 		}
@@ -78,6 +82,26 @@ func TestConfigValidate(t *testing.T) {
 		err := config.Validate()
 		a.NotNil(err)
 		a.Contains(err.Error(), "duplicate signal topic")
+	})
+
+	t.Run("should scope topics by message ID and signal name", func(t *testing.T) {
+		a := assert.New(t)
+
+		config := &Config{
+			Messages: []Message{
+				{ID: 123, DLC: 1, Signals: []Signal{{Name: "Speed", Length: 1, Factor: 1}}},
+				{ID: 456, DLC: 1, Signals: []Signal{{Name: "Speed", Length: 1, Factor: 1}}},
+			},
+			Topics: []SignalTopic{
+				{MessageID: 123, Signal: "Speed", Topic: "vehicle/engine/speed"},
+				{MessageID: 456, Signal: "Speed", Topic: "vehicle/wheel/speed"},
+			},
+		}
+
+		err := config.Validate()
+		a.Nil(err)
+		a.Equal("vehicle/engine/speed", config.Messages[0].Signals[0].Topic)
+		a.Equal("vehicle/wheel/speed", config.Messages[1].Signals[0].Topic)
 	})
 
 	t.Run("should return error for invalid message", func(t *testing.T) {
@@ -105,8 +129,9 @@ func TestSignalTopicValidate(t *testing.T) {
 		a := assert.New(t)
 
 		topic := &SignalTopic{
-			Topic:  "vehicle/engine/speed",
-			Signal: "Speed",
+			MessageID: 123,
+			Topic:     "vehicle/engine/speed",
+			Signal:    "Speed",
 		}
 
 		err := topic.Validate()
@@ -117,8 +142,9 @@ func TestSignalTopicValidate(t *testing.T) {
 		a := assert.New(t)
 
 		topic := &SignalTopic{
-			Topic:  "vehicle/engine/speed",
-			Signal: "",
+			MessageID: 123,
+			Topic:     "vehicle/engine/speed",
+			Signal:    "",
 		}
 
 		err := topic.Validate()
@@ -129,8 +155,9 @@ func TestSignalTopicValidate(t *testing.T) {
 		a := assert.New(t)
 
 		topic := &SignalTopic{
-			Topic:  "",
-			Signal: "Speed",
+			MessageID: 123,
+			Topic:     "",
+			Signal:    "Speed",
 		}
 
 		err := topic.Validate()
@@ -141,8 +168,9 @@ func TestSignalTopicValidate(t *testing.T) {
 		a := assert.New(t)
 
 		topic := &SignalTopic{
-			Topic:  "",
-			Signal: "",
+			MessageID: 123,
+			Topic:     "",
+			Signal:    "",
 		}
 
 		err := topic.Validate()


### PR DESCRIPTION
## Summary

- Replace `TP_` MQTT topic declarations with standard `CM_ SG_` DBC comments.
- Scope topic associations by message ID and signal name.
- Update parsing, validation, tests, fixtures, and README examples.

## Testing

- Not run.