### PR TITLE
fix: use correct ESP-IDF TWAI include

### DIFF
--- a/codegen/espidf/vera_espidf.h.tmpl
+++ b/codegen/espidf/vera_espidf.h.tmpl
@@ -2,7 +2,7 @@
 #define VERA_ESPIDF_H
 
 #include "vera.h"
-#include "driver/twai.h"
+#include "esp_twai.h"
 
 vera_err_t vera_decode_espidf_rx_frame(const twai_frame_t* frame, vera_decoding_result_t* result);
 


### PR DESCRIPTION
## Summary
- Update the ESP-IDF template to include `esp_twai.h`.
- Remove the outdated `driver/twai.h` include.

## Testing
- Not run; template-only include change.