### PR TITLE
fix: pass frame pointer to STM32 HAL decoder

### DIFF
--- a/codegen/stm32hal/codegen_test.go
+++ b/codegen/stm32hal/codegen_test.go
@@ -1,0 +1,20 @@
+package stm32hal
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/ApexCorse/vera"
+)
+
+func TestGenerateSourcePassesFramePointerToCoreDecoder(t *testing.T) {
+	var source bytes.Buffer
+	if err := GenerateSource(&source, &vera.Config{}); err != nil {
+		t.Fatalf("GenerateSource() error = %v", err)
+	}
+
+	if !strings.Contains(source.String(), "vera_decode_can_frame(&vera_frame, result)") {
+		t.Error("generated STM32 HAL decoder must pass the address of its local vera frame")
+	}
+}

--- a/codegen/stm32hal/vera_stm32hal.c.tmpl
+++ b/codegen/stm32hal/vera_stm32hal.c.tmpl
@@ -14,7 +14,7 @@ vera_err_t vera_decode_stm32hal_rx_frame(
 	};
 	memcpy(vera_frame.data, data, frame->DLC);
 
-	return vera_decode_can_frame(vera_frame, result);
+	return vera_decode_can_frame(&vera_frame, result);
 }
 
 {{- range .Messages}}


### PR DESCRIPTION
## Summary

- Pass the local CAN frame address to `vera_decode_can_frame` in generated STM32 HAL code.
- Add a regression test verifying the generated decoder uses the frame pointer.

## Testing

- `go test ./codegen/stm32hal`