### PR TITLE
fix: parse NS_ and BU_ DBC sections

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -55,6 +55,25 @@ func Parse(r io.Reader) (*Config, error) {
 			if signalTopic != nil {
 				config.Topics = append(config.Topics, *signalTopic)
 			}
+		} else if strings.HasPrefix(lines[i], "BU_:") {
+			nodesStr := strings.TrimPrefix(lines[i], "BU_:")
+			nodeNames := strings.Fields(nodesStr)
+			for _, n := range nodeNames {
+				config.Nodes = append(config.Nodes, Node(n))
+			}
+		} else if strings.HasPrefix(lines[i], "NS_ :") {
+			j := i + 1
+			for ; j < len(lines); j++ {
+				line := strings.TrimSpace(lines[j])
+				if line == "" {
+					continue
+				}
+				if strings.Contains(line, " ") || strings.Contains(line, ":") {
+					break
+				}
+				config.NewSymbols = append(config.NewSymbols, line)
+			}
+			i = j - 1
 		}
 	}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -105,3 +105,36 @@ CM_ SG_ 123 Speed "vera:mqtt-topic=vehicle/engine/speed";`
 		a.Len(config.Topics, 1)
 	})
 }
+
+func TestParse_WithNodesAndSymbols(t *testing.T) {
+	t.Run("should parse config with nodes and symbols", func(t *testing.T) {
+		a := assert.New(t)
+
+		configStr := `NS_ :
+	BA_
+	CM_
+	VAL_
+BU_: DriverGateway EngineGateway ABS
+BO_ 123 EngineSpeed: 3 Engine
+   SG_ EngineSpeed : 0|16@1+ (0.1,0) [0|8000] "RPM" DriverGateway
+	SG_ OilTemperature : 16|8@1- (1,-40) [-40|150] "ºC" DriverGateway,EngineGateway`
+
+		reader := strings.NewReader(configStr)
+
+		config, err := Parse(reader)
+		a.Nil(err)
+		a.NotNil(config)
+
+		a.Len(config.Messages, 1)
+
+		a.Len(config.Nodes, 3)
+		a.Equal(Node("DriverGateway"), config.Nodes[0])
+		a.Equal(Node("EngineGateway"), config.Nodes[1])
+		a.Equal(Node("ABS"), config.Nodes[2])
+
+		a.Len(config.NewSymbols, 3)
+		a.Equal("BA_", config.NewSymbols[0])
+		a.Equal("CM_", config.NewSymbols[1])
+		a.Equal("VAL_", config.NewSymbols[2])
+	})
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -137,4 +137,49 @@ BO_ 123 EngineSpeed: 3 Engine
 		a.Equal("CM_", config.NewSymbols[1])
 		a.Equal("VAL_", config.NewSymbols[2])
 	})
+
+	t.Run("should handle empty BU_ and NS_ sections", func(t *testing.T) {
+		a := assert.New(t)
+
+		configStr := `NS_ :
+BU_: 
+BO_ 123 EngineSpeed: 3 Engine
+   SG_ EngineSpeed : 0|16@1+ (0.1,0) [0|8000] "RPM" DriverGateway`
+
+		reader := strings.NewReader(configStr)
+		config, err := Parse(reader)
+
+		a.Nil(err)
+		a.NotNil(config)
+
+		a.Len(config.Nodes, 0)
+		a.Len(config.NewSymbols, 0)
+		a.Len(config.Messages, 1)
+	})
+
+	t.Run("should skip unrelated DBC instructions and comments", func(t *testing.T) {
+		a := assert.New(t)
+
+		configStr := `CM_ "This is a comment"
+NS_ :
+	BA_
+	CM_
+BA_ "This is an attribute"
+BU_: Gateway Engine
+VAL_ 123 "This is a value"`
+
+		reader := strings.NewReader(configStr)
+		config, err := Parse(reader)
+
+		a.Nil(err)
+		a.NotNil(config)
+
+		a.Len(config.Nodes, 2)
+		a.Equal(Node("Gateway"), config.Nodes[0])
+		a.Equal(Node("Engine"), config.Nodes[1])
+
+		a.Len(config.NewSymbols, 2)
+		a.Equal("BA_", config.NewSymbols[0])
+		a.Equal("CM_", config.NewSymbols[1])
+	})
 }

--- a/types.go
+++ b/types.go
@@ -1,8 +1,10 @@
 package vera
 
 type Config struct {
-	Messages []Message
-	Topics   []SignalTopic
+	Messages   []Message
+	Topics     []SignalTopic
+	Nodes      []Node
+	NewSymbols []string
 }
 
 type Node string


### PR DESCRIPTION
Addresses #45.

## Description
This Pull Request implements parsing support for the standard CAN DBC file headers `NS_` and `BU_`.

### Changes Made:
* **`types.go`**: Added `Nodes` and `NewSymbols` fields inside the `Config` struct to store the extracted data.
* **`parser.go`**: Added parsing logic to intercept `BU_:` and `NS_ :` prefixes, correctly handling both single-line and multi-line blocks.
* **`parser_test.go`**: Added a dedicated test function (`TestParse_WithNodesAndSymbols`) in line with the project's existing test conventions to verify parsing correctness.

### Notes:
`validator.go` and `validator_test.go` were left unmodified. 
All test pass successfully.