### PR TITLE
refactor: parse DBC definitions with regular expressions

### DIFF
--- a/message.go
+++ b/message.go
@@ -1,9 +1,12 @@
 package vera
 
 import (
+	"regexp"
 	"strconv"
 	"strings"
 )
+
+var messageDefinitionPattern = regexp.MustCompile(`^\s*BO_\s+(\S+)\s+(\S+)\s*:\s+(\S+)\s+(\S+)\s*$`)
 
 type Message struct {
 	Name        string
@@ -93,30 +96,25 @@ func NewMessageFromLines(lines []string, startLineNumber int) (*Message, error) 
 }
 
 func (m *Message) parseDefinition(line string) error {
-	messageDefinitionParts := strings.Fields(line)
-	if len(messageDefinitionParts) != 5 {
+	matches := messageDefinitionPattern.FindStringSubmatch(line)
+	if matches == nil {
 		return errorAtLine(m.lineNumber, `message line definition must be composed of 5 elements:
 BO_ <MessageID> <MessageName>: <DLC> <TransmitterNode>`)
 	}
 
-	messageIDStr := messageDefinitionParts[1]
+	messageIDStr := matches[1]
 	if err := m.parseID(messageIDStr); err != nil {
 		return err
 	}
 
-	messageName := messageDefinitionParts[2]
-	if !strings.HasSuffix(messageName, ":") {
-		return errorAtLine(m.lineNumber, "message name must end with a ':'")
-	}
-	messageName = strings.TrimSuffix(messageName, ":")
-
-	dlcStr := messageDefinitionParts[3]
+	messageName := matches[2]
+	dlcStr := matches[3]
 	dlc, err := strconv.Atoi(dlcStr)
 	if err != nil {
 		return errorAtLine(m.lineNumber, "message DLC must be a base 10 integer")
 	}
 
-	transmitter := messageDefinitionParts[4]
+	transmitter := matches[4]
 
 	m.Name = messageName
 	m.DLC = uint8(dlc)

--- a/parser_test.go
+++ b/parser_test.go
@@ -26,6 +26,18 @@ BO_ 123 EngineSpeed: 3 Engine
 	})
 }
 
+func TestParse_SignalWithSpacesInUnit(t *testing.T) {
+	a := assert.New(t)
+
+	config, err := Parse(strings.NewReader(`BO_ 0x123 Cabin: 8 Gateway
+	SG_ InteriorTemperature: 0|8@1+ (0.5,-40) [-40|87.5] "degrees Celsius" Climate`))
+
+	a.NoError(err)
+	a.Len(config.Messages, 1)
+	a.Len(config.Messages[0].Signals, 1)
+	a.Equal("degrees Celsius", config.Messages[0].Signals[0].Unit)
+}
+
 func TestParseSignalTopicComment(t *testing.T) {
 	t.Run("should parse a valid MQTT topic comment", func(t *testing.T) {
 		a := assert.New(t)

--- a/signal.go
+++ b/signal.go
@@ -1,9 +1,12 @@
 package vera
 
 import (
+	"regexp"
 	"strconv"
 	"strings"
 )
+
+var signalDefinitionPattern = regexp.MustCompile(`^\s*SG_\s+(\S+)\s*:\s*(\S+)\s+(\([^)]*\))\s+(\[[^]]*\])\s+("(?:[^"\\]|\\.)*")(?:\s+(\S+))?\s*$`)
 
 type Signal struct {
 	Name     string
@@ -41,55 +44,35 @@ func NewSignalFromLine(message *Message, line string, lineNumber int) (*Signal, 
 		lineNumber: lineNumber,
 	}
 
-	line = strings.TrimFunc(line, func(r rune) bool {
-		return r == ' ' || r == '\t'
-	})
-
-	if !strings.HasPrefix(line, "SG_") {
-		return nil, errorAtLine(signal.lineNumber, "signal line doesn't start with 'SG_'")
-	}
-
-	lineParts := strings.Fields(line)
-	if err := signal.checkLineStructure(lineParts); err != nil {
-		return nil, err
-	}
-
-	signal.Name = lineParts[1]
-
-	if err := signal.parseBitInfo(message, lineParts[3]); err != nil {
-		return nil, err
-	}
-
-	if err := signal.parseFactorOffset(lineParts[4]); err != nil {
-		return nil, err
-	}
-
-	if err := signal.parseMinMax(lineParts[5]); err != nil {
-		return nil, err
-	}
-
-	if err := signal.parseUnit(lineParts[6]); err != nil {
-		return nil, err
-	}
-
-	if len(lineParts) == 8 {
-		signal.parseReceivers(lineParts[7])
-	}
-
-	return signal, nil
-}
-
-func (s *Signal) checkLineStructure(lineParts []string) error {
-	if len(lineParts) < 7 {
-		return errorAtLine(s.lineNumber, `signal line is not well structured, must adhere to:
+	matches := signalDefinitionPattern.FindStringSubmatch(line)
+	if matches == nil {
+		return nil, errorAtLine(signal.lineNumber, `signal line is not well structured, must adhere to:
 SG_ <SignalName> : <StartBit>|<Length>@<BitOrder><Signed> (<Factor>,<Offset>) [<Min>,<Max>] "<Unit>" <...Receivers>`)
 	}
 
-	if lineParts[2] != ":" {
-		return errorAtLine(s.lineNumber, "signal line has not a ':' between <SignalName> and <StartBit>")
+	signal.Name = matches[1]
+
+	if err := signal.parseBitInfo(message, matches[2]); err != nil {
+		return nil, err
 	}
 
-	return nil
+	if err := signal.parseFactorOffset(matches[3]); err != nil {
+		return nil, err
+	}
+
+	if err := signal.parseMinMax(matches[4]); err != nil {
+		return nil, err
+	}
+
+	if err := signal.parseUnit(matches[5]); err != nil {
+		return nil, err
+	}
+
+	if matches[6] != "" {
+		signal.parseReceivers(matches[6])
+	}
+
+	return signal, nil
 }
 
 func (s *Signal) parseBitInfo(message *Message, signalBitInfo string) error {


### PR DESCRIPTION
## Summary

- Replace field-based parsing with regular expressions for message and signal definitions.
- Support signal units containing spaces and optional receivers.
- Add coverage for signals with multi-word units.

## Testing

- Not run.