### PR TITLE
feat: standardize signal metadata with DBC attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Vera exists to simplify the workflow of working with CAN networks by providing:
 The generated code provides:
 - Signal decoding from raw CAN frames with automatic scaling/offset conversion
 - Signal encoding for creating CAN frames
-- MQTT topic mapping via standard DBC signal comments, to integrate in MQTT networks and pipelines
+- MQTT topic mapping and optional alert metadata via standard DBC signal attributes, to integrate in MQTT networks and pipelines
 - Validation for out-of-bounds values
 
 ## Installation
@@ -86,8 +86,8 @@ The main package (`vera/`) contains the core functionality:
 | `parser.go` | Parses DBC files and returns a `Config` structure |
 | `message.go` | `Message` struct with validation and line parsing |
 | `signal.go` | `Signal` struct with validation and detailed parsing |
-| `types.go` | Shared types (`Config`, `Node`, `Endianness`, `SignalTopic`) |
-| `validator.go` | Validation of DBC content (signal placement, duplicate topics, etc.) |
+| `types.go` | Shared types (`Config`, `Node`, `Endianness`, `SignalMetadata`) |
+| `validator.go` | Validation of DBC content and signal metadata |
 | `errors.go` | Error construction with line number context |
 
 ### Codegen Package Files
@@ -188,25 +188,34 @@ Vera expects DBC files with the following format:
 ```
 BO_ <message_id> <message_name>: <dlc> <transmitter>
     SG_ <signal_name> : <start_bit>|<length>@<endianness><sign> (<factor>,<offset>) [<min>|<max>] "<unit>" <receivers>
-CM_ SG_ <message_id> <signal_name> "vera:mqtt-topic=<mqtt_topic>";
+BA_DEF_ SG_ "VeraMqttTopic" STRING ;
+BA_ "VeraMqttTopic" SG_ <message_id> <signal_name> "<mqtt_topic>";
 ```
 
 **Important notes:**
 - Start bit and length are in **bits**, DLC is in **bytes**
 - Receivers are parsed if present, but not used in code generation
 - Only **little-endian** (endiananness `1`) is currently supported
-- MQTT topics use standard DBC `CM_ SG_` comments and are placed at the same level as `BO_` instructions (not indented)
-- The `vera:mqtt-topic=` prefix keeps MQTT configuration distinct from ordinary signal documentation comments
-- Topics are associated with a specific message ID and signal name
+- Signal metadata uses standard DBC `BA_DEF_ SG_` declarations and `BA_ ... SG_` assignments.
+- Vera recognizes `VeraMqttTopic` (`STRING`), `VeraWarningLow`, `VeraWarningHigh`, `VeraCriticalLow`, `VeraCriticalHigh` (`FLOAT`), and `VeraStaleAfterMs` (`INT`). Every recognized assignment needs a preceding matching declaration.
+- All metadata is optional. Thresholds are alert metadata, separate from a signal's physical `[min|max]` range. `VeraStaleAfterMs` must be greater than zero when present.
+- The legacy `vera:mqtt-topic=` comment format is rejected.
 
 ### Example DBC File
 
 ```
 BO_ 123 EngineSpeed: 6 Engine
     SG_ EngineSpeed : 0|32@1+ (0.1,0) [0|8000] "RPM" DriverGateway
-    SG_ BatteryTemperature : 32|16@1+(12,4) (1,0) [0|8000] "ºC" DriverGateway
-CM_ SG_ 123 EngineSpeed "vera:mqtt-topic=vehicle/engine/speed";
-CM_ SG_ 123 BatteryTemperature "vera:mqtt-topic=vehicle/battery/temperature";
+    SG_ BatteryTemperature : 32|16@1+ (1,0) [0|8000] "ºC" DriverGateway
+BA_DEF_ SG_ "VeraMqttTopic" STRING ;
+BA_DEF_ SG_ "VeraWarningHigh" FLOAT -1000000 1000000;
+BA_DEF_ SG_ "VeraCriticalHigh" FLOAT -1000000 1000000;
+BA_DEF_ SG_ "VeraStaleAfterMs" INT 1 4294967295;
+BA_ "VeraMqttTopic" SG_ 123 EngineSpeed "vehicle/engine/speed";
+BA_ "VeraWarningHigh" SG_ 123 EngineSpeed 7500;
+BA_ "VeraCriticalHigh" SG_ 123 EngineSpeed 7900;
+BA_ "VeraStaleAfterMs" SG_ 123 EngineSpeed 500;
+BA_ "VeraMqttTopic" SG_ 123 BatteryTemperature "vehicle/battery/temperature";
 ```
 
 ## Development

--- a/codegen/vera.c.tmpl
+++ b/codegen/vera.c.tmpl
@@ -111,7 +111,7 @@ vera_err_t vera_decode_can_frame(
 				.offset = {{printf "%.4f" $signal.Offset}},
 				.min = {{printf "%.4f" $signal.Min}},
 				.max = {{printf "%.4f" $signal.Max}},
-				.topic = "{{$signal.Topic}}"
+				.topic = {{printf "%q" $signal.Metadata.MQTTTopic}}
 			};
 			{{- end}}
 

--- a/gentest/config-test.dbc
+++ b/gentest/config-test.dbc
@@ -2,4 +2,5 @@ BO_ 123 Message1: 6 Engine
 	SG_ EngineSpeed : 0|32@1+ (0.1,0) [0|8000] "RPM" DriverGateway
 	SG_ BatteryTemperature : 32|12@1+ (1,400) [0|8000] "ºC" DriverGateway
 
-CM_ SG_ 123 EngineSpeed "vera:mqtt-topic=Engine/Metrics/Speed";
+BA_DEF_ SG_ "VeraMqttTopic" STRING ;
+BA_ "VeraMqttTopic" SG_ 123 EngineSpeed "Engine/Metrics/Speed";

--- a/parser.go
+++ b/parser.go
@@ -3,14 +3,45 @@ package vera
 import (
 	"fmt"
 	"io"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
 )
 
-const mqttTopicCommentPrefix = "vera:mqtt-topic="
+const legacyMQTTTopicCommentPrefix = "vera:mqtt-topic="
 
-var signalCommentPattern = regexp.MustCompile(`^CM_\s+SG_\s+(0x[0-9A-Fa-f]+|[0-9]+)\s+(\S+)\s+"((?:[^"\\]|\\.)*)"\s*;\s*$`)
+const (
+	attributeMQTTTopic    = "VeraMqttTopic"
+	attributeWarningLow   = "VeraWarningLow"
+	attributeWarningHigh  = "VeraWarningHigh"
+	attributeCriticalLow  = "VeraCriticalLow"
+	attributeCriticalHigh = "VeraCriticalHigh"
+	attributeStaleAfterMs = "VeraStaleAfterMs"
+)
+
+var signalAttributeTypes = map[string]string{
+	attributeMQTTTopic:    "STRING",
+	attributeWarningLow:   "FLOAT",
+	attributeWarningHigh:  "FLOAT",
+	attributeCriticalLow:  "FLOAT",
+	attributeCriticalHigh: "FLOAT",
+	attributeStaleAfterMs: "INT",
+}
+
+var (
+	signalAttributeDefinitionPattern = regexp.MustCompile(`^\s*BA_DEF_\s+SG_\s+("(?:[^"\\]|\\.)*")\s+([A-Za-z]+)(?:\s+.*?)?\s*;\s*$`)
+	signalAttributeAssignmentPattern = regexp.MustCompile(`^\s*BA_\s+("(?:[^"\\]|\\.)*")\s+SG_\s+(0x[0-9A-Fa-f]+|[0-9]+)\s+(\S+)\s+(.+?)\s*;\s*$`)
+	signalAttributeNamePattern       = regexp.MustCompile(`^\s*BA_\s+("(?:[^"\\]|\\.)*")`)
+)
+
+type signalAttributeAssignment struct {
+	name       string
+	messageID  uint32
+	signalName string
+	value      string
+	lineNumber int
+}
 
 func Parse(r io.Reader) (*Config, error) {
 	bytes, err := io.ReadAll(r)
@@ -19,22 +50,24 @@ func Parse(r io.Reader) (*Config, error) {
 	}
 	config := &Config{}
 
-	content := string(bytes)
-	content = replaceNewLineCharacters(content)
-
+	content := replaceNewLineCharacters(string(bytes))
 	lines := strings.Split(content, "\n")
-	if len(lines) == 0 {
-		return config, nil
-	}
+	definitions := make(map[string]struct{})
+	assignments := make([]signalAttributeAssignment, 0)
 
 	for i := 0; i < len(lines); i++ {
-		if strings.HasPrefix(lines[i], "BO_") {
+		line := lines[i]
+		trimmedLine := strings.TrimSpace(line)
+
+		if strings.Contains(trimmedLine, legacyMQTTTopicCommentPrefix) {
+			return nil, errorAtLine(i, "legacy MQTT topic comments are not supported; use the %s signal attribute", attributeMQTTTopic)
+		}
+
+		switch {
+		case strings.HasPrefix(trimmedLine, "BO_"):
 			j := i + 1
 			for ; j < len(lines); j++ {
-				line := strings.TrimFunc(lines[j], func(r rune) bool {
-					return r == ' ' || r == '\t'
-				})
-				if !strings.HasPrefix(line, "SG_") {
+				if !strings.HasPrefix(strings.TrimSpace(lines[j]), "SG_") {
 					break
 				}
 			}
@@ -43,25 +76,39 @@ func Parse(r io.Reader) (*Config, error) {
 			if err != nil {
 				return nil, err
 			}
-
 			config.Messages = append(config.Messages, *message)
 			i = j - 1
-		} else if strings.HasPrefix(lines[i], "CM_ SG_") {
-			signalTopic, err := parseSignalTopicComment(lines[i])
+		case strings.HasPrefix(trimmedLine, "BA_DEF_"):
+			name, attributeType, recognized, err := parseSignalAttributeDefinition(trimmedLine)
+			if err != nil {
+				return nil, errorAtLine(i, "%v", err)
+			}
+			if recognized {
+				if _, ok := definitions[name]; ok {
+					return nil, errorAtLine(i, "duplicate definition for signal attribute %s", name)
+				}
+				if attributeType != signalAttributeTypes[name] {
+					return nil, errorAtLine(i, "signal attribute %s must use %s, got %s", name, signalAttributeTypes[name], attributeType)
+				}
+				definitions[name] = struct{}{}
+			}
+		case strings.HasPrefix(trimmedLine, "BA_"):
+			assignment, recognized, err := parseSignalAttributeAssignment(trimmedLine, i)
 			if err != nil {
 				return nil, err
 			}
-
-			if signalTopic != nil {
-				config.Topics = append(config.Topics, *signalTopic)
+			if recognized {
+				if _, ok := definitions[assignment.name]; !ok {
+					return nil, errorAtLine(i, "signal attribute %s requires a preceding BA_DEF_ SG_ declaration", assignment.name)
+				}
+				assignments = append(assignments, *assignment)
 			}
-		} else if strings.HasPrefix(lines[i], "BU_:") {
-			nodesStr := strings.TrimPrefix(lines[i], "BU_:")
-			nodeNames := strings.Fields(nodesStr)
-			for _, n := range nodeNames {
+		case strings.HasPrefix(trimmedLine, "BU_:"):
+			nodesStr := strings.TrimPrefix(trimmedLine, "BU_:")
+			for _, n := range strings.Fields(nodesStr) {
 				config.Nodes = append(config.Nodes, Node(n))
 			}
-		} else if strings.HasPrefix(lines[i], "NS_ :") {
+		case strings.HasPrefix(trimmedLine, "NS_ :"):
 			j := i + 1
 			for ; j < len(lines); j++ {
 				line := strings.TrimSpace(lines[j])
@@ -77,39 +124,178 @@ func Parse(r io.Reader) (*Config, error) {
 		}
 	}
 
+	if err := applySignalAttributeAssignments(config, assignments); err != nil {
+		return nil, err
+	}
+
 	return config, nil
 }
 
-func parseSignalTopicComment(commentLine string) (*SignalTopic, error) {
-	matches := signalCommentPattern.FindStringSubmatch(commentLine)
+func parseSignalAttributeDefinition(line string) (name, attributeType string, recognized bool, err error) {
+	matches := signalAttributeDefinitionPattern.FindStringSubmatch(line)
 	if matches == nil {
-		if strings.Contains(commentLine, mqttTopicCommentPrefix) {
-			return nil, fmt.Errorf(`MQTT topic comment has wrong structure: %s
-Should be:
-	CM_ SG_ <MessageID> <SignalName> "vera:mqtt-topic=<Topic>";`, commentLine)
+		return "", "", false, nil
+	}
+
+	name, err = strconv.Unquote(matches[1])
+	if err != nil {
+		return "", "", false, fmt.Errorf("invalid signal attribute definition name: %w", err)
+	}
+	_, recognized = signalAttributeTypes[name]
+	return name, matches[2], recognized, nil
+}
+
+func parseSignalAttributeAssignment(line string, lineNumber int) (*signalAttributeAssignment, bool, error) {
+	matches := signalAttributeAssignmentPattern.FindStringSubmatch(line)
+	if matches == nil {
+		nameMatches := signalAttributeNamePattern.FindStringSubmatch(line)
+		if nameMatches == nil {
+			return nil, false, nil
+		}
+		name, err := strconv.Unquote(nameMatches[1])
+		if err != nil {
+			return nil, false, errorAtLine(lineNumber, "invalid signal attribute name: %v", err)
+		}
+		if _, ok := signalAttributeTypes[name]; ok {
+			return nil, true, errorAtLine(lineNumber, "signal attribute %s has invalid assignment syntax", name)
+		}
+		return nil, false, nil
+	}
+
+	name, err := strconv.Unquote(matches[1])
+	if err != nil {
+		return nil, false, errorAtLine(lineNumber, "invalid signal attribute name: %v", err)
+	}
+	if _, ok := signalAttributeTypes[name]; !ok {
+		return nil, false, nil
+	}
+
+	messageID, err := strconv.ParseUint(matches[2], 0, 32)
+	if err != nil {
+		return nil, true, errorAtLine(lineNumber, "invalid message ID in signal attribute %s: %v", name, err)
+	}
+
+	return &signalAttributeAssignment{
+		name:       name,
+		messageID:  uint32(messageID),
+		signalName: matches[3],
+		value:      strings.TrimSpace(matches[4]),
+		lineNumber: lineNumber,
+	}, true, nil
+}
+
+func applySignalAttributeAssignments(config *Config, assignments []signalAttributeAssignment) error {
+	messages := make(map[uint32]*Message, len(config.Messages))
+	for i := range config.Messages {
+		messages[config.Messages[i].ID] = &config.Messages[i]
+	}
+
+	seen := make(map[string]struct{}, len(assignments))
+	for _, assignment := range assignments {
+		message, ok := messages[assignment.messageID]
+		if !ok {
+			return errorAtLine(assignment.lineNumber, "signal attribute %s references unknown message %d", assignment.name, assignment.messageID)
 		}
 
-		return nil, nil
+		var signal *Signal
+		for i := range message.Signals {
+			if message.Signals[i].Name == assignment.signalName {
+				signal = &message.Signals[i]
+				break
+			}
+		}
+		if signal == nil {
+			return errorAtLine(assignment.lineNumber, "signal attribute %s references unknown signal %s on message %d", assignment.name, assignment.signalName, assignment.messageID)
+		}
+
+		key := fmt.Sprintf("%d\x00%s\x00%s", assignment.messageID, assignment.signalName, assignment.name)
+		if _, ok := seen[key]; ok {
+			return errorAtLine(assignment.lineNumber, "duplicate signal attribute %s for message %d, signal %s", assignment.name, assignment.messageID, assignment.signalName)
+		}
+		seen[key] = struct{}{}
+
+		if err := setSignalMetadataValue(&signal.Metadata, assignment.name, assignment.value); err != nil {
+			return errorAtLine(assignment.lineNumber, "invalid signal attribute %s: %v", assignment.name, err)
+		}
+	}
+	for _, message := range config.Messages {
+		for _, signal := range message.Signals {
+			if err := signal.Metadata.Validate(); err != nil {
+				return errorAtLine(signal.lineNumber, "signal metadata: %v", err)
+			}
+		}
 	}
 
-	comment, err := strconv.Unquote(`"` + matches[3] + `"`)
+	return nil
+}
+
+func setSignalMetadataValue(metadata *SignalMetadata, name, rawValue string) error {
+	switch name {
+	case attributeMQTTTopic:
+		value, err := parseDBCString(rawValue)
+		if err != nil {
+			return err
+		}
+		if value == "" {
+			return fmt.Errorf("MQTT topic cannot be empty")
+		}
+		metadata.MQTTTopic = value
+	case attributeWarningLow:
+		value, err := parseDBCFloat(rawValue)
+		if err != nil {
+			return err
+		}
+		metadata.WarningLow = &value
+	case attributeWarningHigh:
+		value, err := parseDBCFloat(rawValue)
+		if err != nil {
+			return err
+		}
+		metadata.WarningHigh = &value
+	case attributeCriticalLow:
+		value, err := parseDBCFloat(rawValue)
+		if err != nil {
+			return err
+		}
+		metadata.CriticalLow = &value
+	case attributeCriticalHigh:
+		value, err := parseDBCFloat(rawValue)
+		if err != nil {
+			return err
+		}
+		metadata.CriticalHigh = &value
+	case attributeStaleAfterMs:
+		value, err := strconv.ParseUint(rawValue, 10, 32)
+		if err != nil {
+			return fmt.Errorf("must be an unsigned 32-bit integer: %w", err)
+		}
+		if value == 0 {
+			return fmt.Errorf("must be greater than zero")
+		}
+		staleAfterMs := uint32(value)
+		metadata.StaleAfterMs = &staleAfterMs
+	}
+	return nil
+}
+
+func parseDBCString(rawValue string) (string, error) {
+	if len(rawValue) < 2 || rawValue[0] != '"' || rawValue[len(rawValue)-1] != '"' {
+		return "", fmt.Errorf("must be a quoted string")
+	}
+	value, err := strconv.Unquote(rawValue)
 	if err != nil {
-		return nil, fmt.Errorf("invalid signal comment: %w", err)
+		return "", fmt.Errorf("invalid quoted string: %w", err)
 	}
-	if !strings.HasPrefix(comment, mqttTopicCommentPrefix) {
-		return nil, nil
-	}
+	return value, nil
+}
 
-	messageID, err := strconv.ParseUint(matches[1], 0, 32)
+func parseDBCFloat(rawValue string) (float32, error) {
+	value, err := strconv.ParseFloat(rawValue, 32)
 	if err != nil {
-		return nil, fmt.Errorf("invalid message ID in MQTT topic comment: %w", err)
+		return 0, fmt.Errorf("must be a 32-bit floating-point value: %w", err)
 	}
-
-	signalTopic := &SignalTopic{
-		MessageID: uint32(messageID),
-		Topic:     strings.TrimPrefix(comment, mqttTopicCommentPrefix),
-		Signal:    matches[2],
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, fmt.Errorf("must be finite")
 	}
-
-	return signalTopic, nil
+	return float32(value), nil
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -5,193 +5,208 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestParse(t *testing.T) {
-	t.Run("should return config struct with 2 messages", func(t *testing.T) {
-		a := assert.New(t)
+const metadataDefinitions = `BA_DEF_ SG_ "VeraMqttTopic" STRING ;
+BA_DEF_ SG_ "VeraWarningLow" FLOAT -1000000 1000000;
+BA_DEF_ SG_ "VeraWarningHigh" FLOAT -1000000 1000000;
+BA_DEF_ SG_ "VeraCriticalLow" FLOAT -1000000 1000000;
+BA_DEF_ SG_ "VeraCriticalHigh" FLOAT -1000000 1000000;
+BA_DEF_ SG_ "VeraStaleAfterMs" INT 1 4294967295;`
 
-		configStr := `BO_ 123 EngineSpeed: 3 Engine
-SG_ EngineSpeed : 0|16@1+ (0.1,0) [0|8000] "RPM" DriverGateway
-	SG_ OilTemperature : 16|8@1- (1,-40) [-40|150] "ºC" DriverGateway,EngineGateway
-BO_ 123 EngineSpeed: 3 Engine
-   SG_ EngineSpeed : 0|16@1+ (0.1,0) [0|8000] "RPM" DriverGateway
-	SG_ OilTemperature : 16|8@1- (1,-40) [-40|150] "ºC" DriverGateway,EngineGateway`
-		reader := strings.NewReader(configStr)
+const oneSignalMessage = `BO_ 123 Engine: 8 Engine
+ SG_ Speed : 0|8@1+ (1,0) [0|255] "km/h" Gateway`
 
-		config, err := Parse(reader)
-		a.Nil(err)
-		a.NotNil(config)
-		a.Len(config.Messages, 2)
-	})
+func TestParseSignalMetadata(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		assert  func(*testing.T, *Config)
+		errText string
+	}{
+		{
+			name: "parses all signal metadata attributes",
+			input: metadataDefinitions + "\n" + oneSignalMessage + `
+BA_ "VeraMqttTopic" SG_ 0x7b Speed "vehicle/engine/\"speed";
+BA_ "VeraWarningLow" SG_ 123 Speed 10.5;
+BA_ "VeraWarningHigh" SG_ 123 Speed 90;
+BA_ "VeraCriticalLow" SG_ 123 Speed 5;
+BA_ "VeraCriticalHigh" SG_ 123 Speed 100;
+BA_ "VeraStaleAfterMs" SG_ 123 Speed 500;`,
+			assert: func(t *testing.T, config *Config) {
+				t.Helper()
+				require.Len(t, config.Messages, 1)
+				metadata := config.Messages[0].Signals[0].Metadata
+				assert.Equal(t, `vehicle/engine/"speed`, metadata.MQTTTopic)
+				require.NotNil(t, metadata.WarningLow)
+				assert.Equal(t, float32(10.5), *metadata.WarningLow)
+				require.NotNil(t, metadata.WarningHigh)
+				assert.Equal(t, float32(90), *metadata.WarningHigh)
+				require.NotNil(t, metadata.CriticalLow)
+				assert.Equal(t, float32(5), *metadata.CriticalLow)
+				require.NotNil(t, metadata.CriticalHigh)
+				assert.Equal(t, float32(100), *metadata.CriticalHigh)
+				require.NotNil(t, metadata.StaleAfterMs)
+				assert.Equal(t, uint32(500), *metadata.StaleAfterMs)
+			},
+		},
+		{
+			name: "ignores unrelated attributes and defaults",
+			input: `BA_DEF_ SG_ "Unrelated" STRING ;
+BA_DEF_DEF_ "VeraMqttTopic" "default/topic";
+` + oneSignalMessage + `
+BA_ "Unrelated" SG_ 123 Speed "ignored";`,
+			assert: func(t *testing.T, config *Config) {
+				t.Helper()
+				assert.Equal(t, SignalMetadata{}, config.Messages[0].Signals[0].Metadata)
+			},
+		},
+		{
+			name: "preserves ordinary comments and other DBC sections",
+			input: `CM_ SG_ 123 Speed "Speed in km/h";
+BU_: Gateway Engine
+` + oneSignalMessage,
+			assert: func(t *testing.T, config *Config) {
+				t.Helper()
+				assert.Len(t, config.Messages, 1)
+				assert.Equal(t, []Node{"Gateway", "Engine"}, config.Nodes)
+			},
+		},
+		{
+			name: "rejects legacy topic comment",
+			input: oneSignalMessage + `
+CM_ SG_ 123 Speed "vera:mqtt-topic=vehicle/speed";`,
+			errText: "legacy MQTT topic comments are not supported",
+		},
+		{
+			name: "rejects malformed legacy topic comment",
+			input: oneSignalMessage + `
+CM_ SG_ 123 Speed vera:mqtt-topic=vehicle/speed`,
+			errText: "legacy MQTT topic comments are not supported",
+		},
+		{
+			name: "requires a preceding declaration",
+			input: oneSignalMessage + `
+BA_ "VeraMqttTopic" SG_ 123 Speed "vehicle/speed";`,
+			errText: "requires a preceding BA_DEF_ SG_ declaration",
+		},
+		{
+			name: "rejects wrong declaration type",
+			input: `BA_DEF_ SG_ "VeraMqttTopic" INT 0 100;
+` + oneSignalMessage,
+			errText: "must use STRING, got INT",
+		},
+		{
+			name: "rejects duplicate assignments",
+			input: metadataDefinitions + "\n" + oneSignalMessage + `
+BA_ "VeraMqttTopic" SG_ 123 Speed "vehicle/one";
+BA_ "VeraMqttTopic" SG_ 123 Speed "vehicle/two";`,
+			errText: "duplicate signal attribute VeraMqttTopic",
+		},
+		{
+			name: "rejects unknown message",
+			input: metadataDefinitions + "\n" + oneSignalMessage + `
+BA_ "VeraMqttTopic" SG_ 999 Speed "vehicle/speed";`,
+			errText: "references unknown message 999",
+		},
+		{
+			name: "rejects unknown signal",
+			input: metadataDefinitions + "\n" + oneSignalMessage + `
+BA_ "VeraMqttTopic" SG_ 123 Unknown "vehicle/speed";`,
+			errText: "references unknown signal Unknown",
+		},
+		{
+			name: "rejects empty MQTT topic",
+			input: metadataDefinitions + "\n" + oneSignalMessage + `
+BA_ "VeraMqttTopic" SG_ 123 Speed "";`,
+			errText: "MQTT topic cannot be empty",
+		},
+		{
+			name: "rejects invalid known assignment syntax",
+			input: metadataDefinitions + "\n" + oneSignalMessage + `
+BA_ "VeraMqttTopic" SG_ 123 Speed vehicle/speed;`,
+			errText: "must be a quoted string",
+		},
+		{
+			name: "rejects zero stale after",
+			input: metadataDefinitions + "\n" + oneSignalMessage + `
+BA_ "VeraStaleAfterMs" SG_ 123 Speed 0;`,
+			errText: "must be greater than zero",
+		},
+		{
+			name: "rejects stale after overflow",
+			input: metadataDefinitions + "\n" + oneSignalMessage + `
+BA_ "VeraStaleAfterMs" SG_ 123 Speed 4294967296;`,
+			errText: "unsigned 32-bit integer",
+		},
+		{
+			name: "rejects non-finite threshold",
+			input: metadataDefinitions + "\n" + oneSignalMessage + `
+BA_ "VeraWarningLow" SG_ 123 Speed NaN;`,
+			errText: "must be finite",
+		},
+		{
+			name: "rejects incoherent threshold order",
+			input: metadataDefinitions + "\n" + oneSignalMessage + `
+BA_ "VeraCriticalLow" SG_ 123 Speed 20;
+BA_ "VeraWarningLow" SG_ 123 Speed 10;`,
+			errText: "critical low must be less than or equal to warning low",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := Parse(strings.NewReader(tt.input))
+			if tt.errText != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errText)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, config)
+			tt.assert(t, config)
+		})
+	}
 }
 
-func TestParse_SignalWithSpacesInUnit(t *testing.T) {
-	a := assert.New(t)
-
-	config, err := Parse(strings.NewReader(`BO_ 0x123 Cabin: 8 Gateway
-	SG_ InteriorTemperature: 0|8@1+ (0.5,-40) [-40|87.5] "degrees Celsius" Climate`))
-
-	a.NoError(err)
-	a.Len(config.Messages, 1)
-	a.Len(config.Messages[0].Signals, 1)
-	a.Equal("degrees Celsius", config.Messages[0].Signals[0].Unit)
-}
-
-func TestParseSignalTopicComment(t *testing.T) {
-	t.Run("should parse a valid MQTT topic comment", func(t *testing.T) {
-		a := assert.New(t)
-
-		topic, err := parseSignalTopicComment(`CM_ SG_ 123 EngineSpeed "vera:mqtt-topic=vehicle/engine/speed";`)
-		a.Nil(err)
-		a.NotNil(topic)
-		a.Equal(uint32(123), topic.MessageID)
-		a.Equal("EngineSpeed", topic.Signal)
-		a.Equal("vehicle/engine/speed", topic.Topic)
-	})
-
-	t.Run("should return an error for a malformed MQTT topic comment", func(t *testing.T) {
-		a := assert.New(t)
-
-		topic, err := parseSignalTopicComment(`CM_ SG_ 123 EngineSpeed "vera:mqtt-topic=vehicle/engine/speed"`)
-		a.Error(err)
-		a.Nil(topic)
-		a.Contains(err.Error(), "MQTT topic comment has wrong structure")
-	})
-
-	t.Run("should ignore regular signal comments", func(t *testing.T) {
-		a := assert.New(t)
-
-		topic, err := parseSignalTopicComment(`CM_ SG_ 123 EngineSpeed "Engine speed in RPM";`)
-		a.Nil(err)
-		a.Nil(topic)
-	})
-}
-
-func TestParse_WithTopics(t *testing.T) {
-	t.Run("should parse config with topics", func(t *testing.T) {
-		a := assert.New(t)
-
-		configStr := `BO_ 123 EngineSpeed: 8 Engine
-	SG_ Speed : 0|2@1+ (0.1,0) [0|100] "km/h" Gateway
-CM_ SG_ 123 Speed "vera:mqtt-topic=vehicle/engine/speed";`
-		reader := strings.NewReader(configStr)
-
-		config, err := Parse(reader)
-		a.Nil(err)
-		a.NotNil(config)
-		a.Len(config.Messages, 1)
-		a.Len(config.Topics, 1)
-		a.Equal(uint32(123), config.Topics[0].MessageID)
-		a.Equal("Speed", config.Topics[0].Signal)
-		a.Equal("vehicle/engine/speed", config.Topics[0].Topic)
-	})
-
-	t.Run("should return empty config for empty input", func(t *testing.T) {
-		a := assert.New(t)
-
-		configStr := ``
-		reader := strings.NewReader(configStr)
-
-		config, err := Parse(reader)
-		a.Nil(err)
-		a.NotNil(config)
-		a.Len(config.Messages, 0)
-		a.Len(config.Topics, 0)
-	})
-
-	t.Run("should skip non-topic DBC instructions and comments", func(t *testing.T) {
-		a := assert.New(t)
-
-		configStr := `CM_ "This is a comment"
-BO_ 123 EngineSpeed: 8 Engine
-	SG_ Speed : 0|2@1+ (0.1,0) [0|100] "km/h" Gateway
-BA_ "AttributeName" "AttributeValue"
-CM_ SG_ 123 Speed "vera:mqtt-topic=vehicle/engine/speed";`
-		reader := strings.NewReader(configStr)
-
-		config, err := Parse(reader)
-		a.Nil(err)
-		a.NotNil(config)
-		a.Len(config.Messages, 1)
-		a.Len(config.Topics, 1)
-	})
-}
-
-func TestParse_WithNodesAndSymbols(t *testing.T) {
-	t.Run("should parse config with nodes and symbols", func(t *testing.T) {
-		a := assert.New(t)
-
-		configStr := `NS_ :
+func TestParseBasicDBCSections(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		messageCount int
+		nodes        []Node
+		symbols      []string
+	}{
+		{
+			name:         "empty input",
+			input:        "",
+			messageCount: 0,
+		},
+		{
+			name: "messages nodes and symbols",
+			input: `NS_ :
 	BA_
 	CM_
-	VAL_
 BU_: DriverGateway EngineGateway ABS
 BO_ 123 EngineSpeed: 3 Engine
    SG_ EngineSpeed : 0|16@1+ (0.1,0) [0|8000] "RPM" DriverGateway
-	SG_ OilTemperature : 16|8@1- (1,-40) [-40|150] "ºC" DriverGateway,EngineGateway`
+BO_ 0x124 Temperature: 1 Engine
+   SG_ OilTemperature : 0|8@1- (1,-40) [-40|150] "degrees Celsius" DriverGateway`,
+			messageCount: 2,
+			nodes:        []Node{"DriverGateway", "EngineGateway", "ABS"},
+			symbols:      []string{"BA_", "CM_"},
+		},
+	}
 
-		reader := strings.NewReader(configStr)
-
-		config, err := Parse(reader)
-		a.Nil(err)
-		a.NotNil(config)
-
-		a.Len(config.Messages, 1)
-
-		a.Len(config.Nodes, 3)
-		a.Equal(Node("DriverGateway"), config.Nodes[0])
-		a.Equal(Node("EngineGateway"), config.Nodes[1])
-		a.Equal(Node("ABS"), config.Nodes[2])
-
-		a.Len(config.NewSymbols, 3)
-		a.Equal("BA_", config.NewSymbols[0])
-		a.Equal("CM_", config.NewSymbols[1])
-		a.Equal("VAL_", config.NewSymbols[2])
-	})
-
-	t.Run("should handle empty BU_ and NS_ sections", func(t *testing.T) {
-		a := assert.New(t)
-
-		configStr := `NS_ :
-BU_: 
-BO_ 123 EngineSpeed: 3 Engine
-   SG_ EngineSpeed : 0|16@1+ (0.1,0) [0|8000] "RPM" DriverGateway`
-
-		reader := strings.NewReader(configStr)
-		config, err := Parse(reader)
-
-		a.Nil(err)
-		a.NotNil(config)
-
-		a.Len(config.Nodes, 0)
-		a.Len(config.NewSymbols, 0)
-		a.Len(config.Messages, 1)
-	})
-
-	t.Run("should skip unrelated DBC instructions and comments", func(t *testing.T) {
-		a := assert.New(t)
-
-		configStr := `CM_ "This is a comment"
-NS_ :
-	BA_
-	CM_
-BA_ "This is an attribute"
-BU_: Gateway Engine
-VAL_ 123 "This is a value"`
-
-		reader := strings.NewReader(configStr)
-		config, err := Parse(reader)
-
-		a.Nil(err)
-		a.NotNil(config)
-
-		a.Len(config.Nodes, 2)
-		a.Equal(Node("Gateway"), config.Nodes[0])
-		a.Equal(Node("Engine"), config.Nodes[1])
-
-		a.Len(config.NewSymbols, 2)
-		a.Equal("BA_", config.NewSymbols[0])
-		a.Equal("CM_", config.NewSymbols[1])
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := Parse(strings.NewReader(tt.input))
+			require.NoError(t, err)
+			assert.Len(t, config.Messages, tt.messageCount)
+			assert.Equal(t, tt.nodes, config.Nodes)
+			assert.Equal(t, tt.symbols, config.NewSymbols)
+		})
+	}
 }

--- a/signal.go
+++ b/signal.go
@@ -20,7 +20,7 @@ type Signal struct {
 	Max       float32
 	Unit      string
 	Receivers []Node
-	Topic     string
+	Metadata  SignalMetadata
 
 	lineNumber int
 }
@@ -34,6 +34,9 @@ func (s *Signal) Validate() error {
 	}
 	if s.Factor == 0 {
 		return errorAtLine(s.lineNumber, "signal factor cannot be zero")
+	}
+	if err := s.Metadata.Validate(); err != nil {
+		return errorAtLine(s.lineNumber, "signal metadata: %v", err)
 	}
 
 	return nil

--- a/types.go
+++ b/types.go
@@ -2,7 +2,6 @@ package vera
 
 type Config struct {
 	Messages   []Message
-	Topics     []SignalTopic
 	Nodes      []Node
 	NewSymbols []string
 }
@@ -16,8 +15,14 @@ const (
 	BigEndian
 )
 
-type SignalTopic struct {
-	MessageID uint32
-	Topic     string
-	Signal    string
+// SignalMetadata is optional, signal-scoped configuration stored in DBC
+// attributes. Its fields intentionally use pointers where zero is a valid
+// configured value and must be distinguishable from an absent attribute.
+type SignalMetadata struct {
+	MQTTTopic    string
+	WarningLow   *float32
+	WarningHigh  *float32
+	CriticalLow  *float32
+	CriticalHigh *float32
+	StaleAfterMs *uint32
 }

--- a/validator.go
+++ b/validator.go
@@ -2,44 +2,28 @@ package vera
 
 import "fmt"
 
-type signalTopicKey struct {
-	messageID uint32
-	signal    string
-}
-
 func (c *Config) Validate() error {
-	topicsMap := make(map[signalTopicKey]string)
-	for i, t := range c.Topics {
-		if err := t.Validate(); err != nil {
-			return fmt.Errorf("topic Nº%d: %w", i, err)
-		}
-
-		key := signalTopicKey{messageID: t.MessageID, signal: t.Signal}
-		if _, ok := topicsMap[key]; ok {
-			return fmt.Errorf("duplicate signal topic for message %d, signal %s", t.MessageID, t.Signal)
-		}
-		topicsMap[key] = t.Topic
-	}
-
 	for i := range c.Messages {
 		if err := c.Messages[i].Validate(); err != nil {
 			return err
-		}
-
-		for j := range c.Messages[i].Signals {
-			key := signalTopicKey{messageID: c.Messages[i].ID, signal: c.Messages[i].Signals[j].Name}
-			if value, ok := topicsMap[key]; ok {
-				c.Messages[i].Signals[j].Topic = value
-			}
 		}
 	}
 
 	return nil
 }
 
-func (t *SignalTopic) Validate() error {
-	if t.Signal == "" || t.Topic == "" {
-		return fmt.Errorf("signal topic must have a 'signal' name and a 'topic' name")
+func (m SignalMetadata) Validate() error {
+	if m.StaleAfterMs != nil && *m.StaleAfterMs == 0 {
+		return fmt.Errorf("stale-after milliseconds must be greater than zero")
+	}
+	if m.CriticalLow != nil && m.WarningLow != nil && *m.CriticalLow > *m.WarningLow {
+		return fmt.Errorf("critical low must be less than or equal to warning low")
+	}
+	if m.WarningLow != nil && m.WarningHigh != nil && *m.WarningLow > *m.WarningHigh {
+		return fmt.Errorf("warning low must be less than or equal to warning high")
+	}
+	if m.WarningHigh != nil && m.CriticalHigh != nil && *m.WarningHigh > *m.CriticalHigh {
+		return fmt.Errorf("warning high must be less than or equal to critical high")
 	}
 
 	return nil

--- a/validator_test.go
+++ b/validator_test.go
@@ -4,176 +4,110 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+func float32Pointer(value float32) *float32 { return &value }
+func uint32Pointer(value uint32) *uint32    { return &value }
+
 func TestConfigValidate(t *testing.T) {
-	t.Run("should validate valid config", func(t *testing.T) {
-		a := assert.New(t)
-
-		config := &Config{
-			Messages: []Message{
-				{
-					ID:          123,
-					Name:        "EngineSpeed",
-					DLC:         1,
-					Transmitter: "Engine",
-					Signals: []Signal{
-						{
-							Name:     "Speed",
-							StartBit: 0,
-							Length:   2,
-							Factor:   0.1,
-							Min:      0,
-							Max:      100,
-						},
+	tests := []struct {
+		name    string
+		config  Config
+		errText string
+	}{
+		{
+			name: "valid metadata can omit every field",
+			config: Config{Messages: []Message{{
+				DLC: 1,
+				Signals: []Signal{{
+					Name: "Speed", Length: 1, Factor: 1,
+				}},
+			}}},
+		},
+		{
+			name: "valid independent bounds",
+			config: Config{Messages: []Message{{
+				DLC: 1,
+				Signals: []Signal{{
+					Name: "Speed", Length: 1, Factor: 1,
+					Metadata: SignalMetadata{
+						CriticalLow:  float32Pointer(10),
+						CriticalHigh: float32Pointer(5),
 					},
-				},
-			},
-			Topics: []SignalTopic{
-				{
-					MessageID: 123,
-					Topic:     "vehicle/engine/speed",
-					Signal:    "Speed",
-				},
-			},
-		}
+				}},
+			}}},
+		},
+		{
+			name: "rejects zero stale after",
+			config: Config{Messages: []Message{{
+				DLC: 1,
+				Signals: []Signal{{
+					Name: "Speed", Length: 1, Factor: 1,
+					Metadata: SignalMetadata{StaleAfterMs: uint32Pointer(0)},
+				}},
+			}}},
+			errText: "stale-after milliseconds must be greater than zero",
+		},
+		{
+			name: "rejects critical low above warning low",
+			config: Config{Messages: []Message{{
+				DLC: 1,
+				Signals: []Signal{{
+					Name: "Speed", Length: 1, Factor: 1,
+					Metadata: SignalMetadata{
+						CriticalLow: float32Pointer(11),
+						WarningLow:  float32Pointer(10),
+					},
+				}},
+			}}},
+			errText: "critical low must be less than or equal to warning low",
+		},
+		{
+			name: "rejects warning low above warning high",
+			config: Config{Messages: []Message{{
+				DLC: 1,
+				Signals: []Signal{{
+					Name: "Speed", Length: 1, Factor: 1,
+					Metadata: SignalMetadata{
+						WarningLow:  float32Pointer(11),
+						WarningHigh: float32Pointer(10),
+					},
+				}},
+			}}},
+			errText: "warning low must be less than or equal to warning high",
+		},
+		{
+			name: "rejects warning high above critical high",
+			config: Config{Messages: []Message{{
+				DLC: 1,
+				Signals: []Signal{{
+					Name: "Speed", Length: 1, Factor: 1,
+					Metadata: SignalMetadata{
+						WarningHigh:  float32Pointer(11),
+						CriticalHigh: float32Pointer(10),
+					},
+				}},
+			}}},
+			errText: "warning high must be less than or equal to critical high",
+		},
+		{
+			name:    "retains existing message validation",
+			config:  Config{Messages: []Message{{DLC: 9}}},
+			errText: "message DLC must be a number between 1 and 8",
+		},
+	}
 
-		err := config.Validate()
-		a.Nil(err)
-		a.Equal("vehicle/engine/speed", config.Messages[0].Signals[0].Topic)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.errText == "" {
+				require.NoError(t, err)
+				return
+			}
 
-	t.Run("should return error for invalid topic", func(t *testing.T) {
-		a := assert.New(t)
-
-		config := &Config{
-			Topics: []SignalTopic{
-				{
-					MessageID: 123,
-					Topic:     "",
-					Signal:    "Speed",
-				},
-			},
-		}
-
-		err := config.Validate()
-		a.NotNil(err)
-		a.Contains(err.Error(), "topic Nº0")
-	})
-
-	t.Run("should return error for duplicate signal topic", func(t *testing.T) {
-		a := assert.New(t)
-
-		config := &Config{
-			Topics: []SignalTopic{
-				{
-					MessageID: 123,
-					Topic:     "vehicle/engine/speed",
-					Signal:    "Speed",
-				},
-				{
-					MessageID: 123,
-					Topic:     "vehicle/engine/rpm",
-					Signal:    "Speed",
-				},
-			},
-		}
-
-		err := config.Validate()
-		a.NotNil(err)
-		a.Contains(err.Error(), "duplicate signal topic")
-	})
-
-	t.Run("should scope topics by message ID and signal name", func(t *testing.T) {
-		a := assert.New(t)
-
-		config := &Config{
-			Messages: []Message{
-				{ID: 123, DLC: 1, Signals: []Signal{{Name: "Speed", Length: 1, Factor: 1}}},
-				{ID: 456, DLC: 1, Signals: []Signal{{Name: "Speed", Length: 1, Factor: 1}}},
-			},
-			Topics: []SignalTopic{
-				{MessageID: 123, Signal: "Speed", Topic: "vehicle/engine/speed"},
-				{MessageID: 456, Signal: "Speed", Topic: "vehicle/wheel/speed"},
-			},
-		}
-
-		err := config.Validate()
-		a.Nil(err)
-		a.Equal("vehicle/engine/speed", config.Messages[0].Signals[0].Topic)
-		a.Equal("vehicle/wheel/speed", config.Messages[1].Signals[0].Topic)
-	})
-
-	t.Run("should return error for invalid message", func(t *testing.T) {
-		a := assert.New(t)
-
-		config := &Config{
-			Messages: []Message{
-				{
-					ID:          123,
-					Name:        "EngineSpeed",
-					DLC:         9, // Invalid: > 8 bytes
-					Transmitter: "Engine",
-				},
-			},
-		}
-
-		err := config.Validate()
-		a.NotNil(err)
-		a.Contains(err.Error(), "message DLC must be a number between 1 and 8")
-	})
-}
-
-func TestSignalTopicValidate(t *testing.T) {
-	t.Run("should validate topic with valid signal and topic", func(t *testing.T) {
-		a := assert.New(t)
-
-		topic := &SignalTopic{
-			MessageID: 123,
-			Topic:     "vehicle/engine/speed",
-			Signal:    "Speed",
-		}
-
-		err := topic.Validate()
-		a.Nil(err)
-	})
-
-	t.Run("should return error when signal is empty", func(t *testing.T) {
-		a := assert.New(t)
-
-		topic := &SignalTopic{
-			MessageID: 123,
-			Topic:     "vehicle/engine/speed",
-			Signal:    "",
-		}
-
-		err := topic.Validate()
-		a.Error(err)
-	})
-
-	t.Run("should return error when topic is empty", func(t *testing.T) {
-		a := assert.New(t)
-
-		topic := &SignalTopic{
-			MessageID: 123,
-			Topic:     "",
-			Signal:    "Speed",
-		}
-
-		err := topic.Validate()
-		a.Error(err)
-	})
-
-	t.Run("should return error when both are empty", func(t *testing.T) {
-		a := assert.New(t)
-
-		topic := &SignalTopic{
-			MessageID: 123,
-			Topic:     "",
-			Signal:    "",
-		}
-
-		err := topic.Validate()
-		a.Error(err)
-	})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errText)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- Replace legacy MQTT topic comments with standard DBC signal attributes.
- Add optional MQTT topic, alert threshold, and stale-after metadata.
- Validate metadata declarations, assignments, references, types, and threshold ordering.
- Update code generation, tests, fixtures, and documentation.

## Testing

- Not run; change request content only.