### PR TITLE
chore: ignore generated test artifacts

### DIFF
--- a/gentest/.gitignore
+++ b/gentest/.gitignore
@@ -1,1 +1,3 @@
 vera.*
+test
+*.o


### PR DESCRIPTION
## Summary

- Ignore generated `test` binaries in `gentest`.
- Ignore generated object files in `gentest`.

## Testing

- Not run; this change only updates `.gitignore`.